### PR TITLE
rclone: fix rclone-web missing

### DIFF
--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -25,19 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - browserless
-          - cloudflared
-          - jellyfin
-          - lobehub
-          - postgres
-          - qbittorrent
           - rclone
-          - rustfs
-          - searxng
-          - siyuan
-          - valkey
-          - vaultwarden
-          - xray
         platform: [linux/amd64, linux/arm64]
         include:
           - platform: linux/amd64
@@ -100,19 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - browserless
-          - cloudflared
-          - jellyfin
-          - lobehub
-          - postgres
-          - qbittorrent
           - rclone
-          - rustfs
-          - searxng
-          - siyuan
-          - valkey
-          - vaultwarden
-          - xray
     name: Merge ${{ matrix.package }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -25,7 +25,19 @@ jobs:
       fail-fast: false
       matrix:
         package:
+          - browserless
+          - cloudflared
+          - jellyfin
+          - lobehub
+          - postgres
+          - qbittorrent
           - rclone
+          - rustfs
+          - searxng
+          - siyuan
+          - valkey
+          - vaultwarden
+          - xray
         platform: [linux/amd64, linux/arm64]
         include:
           - platform: linux/amd64
@@ -88,7 +100,19 @@ jobs:
       fail-fast: false
       matrix:
         package:
+          - browserless
+          - cloudflared
+          - jellyfin
+          - lobehub
+          - postgres
+          - qbittorrent
           - rclone
+          - rustfs
+          - searxng
+          - siyuan
+          - valkey
+          - vaultwarden
+          - xray
     name: Merge ${{ matrix.package }}
     runs-on: ubuntu-latest
     steps:

--- a/patch/package.json
+++ b/patch/package.json
@@ -69,6 +69,13 @@
       "source_branch": "master",
       "version": "1.73.4"
     },
+    "rclone_web": {
+      "patch": "https://github.com/hezhijie0327/DockerimageBuilder.git",
+      "patch_branch": "main",
+      "source": "https://github.com/rclone/rclone-web.git",
+      "source_branch": "main",
+      "version": "1.0.4"
+    },
     "rustfs": {
       "patch": "https://github.com/hezhijie0327/DockerimageBuilder.git",
       "patch_branch": "main",

--- a/patch/release.sh
+++ b/patch/release.sh
@@ -15,6 +15,7 @@ export OPENSSL_VERSION_FIXED=""
 export QBITTORRENT_VERSION_FIXED=""
 export QSTASH_VERSION_FIXED=""
 export RCLONE_VERSION_FIXED=""
+export RCLONE_WEB_VERSION_FIXED=""
 export RUSTFS_VERSION_FIXED="1.0.0"
 export RUSTFS_WEB_VERSION_FIXED=""
 export SEARXNG_VERSION_FIXED="1.0.0"
@@ -39,6 +40,7 @@ function GetLatestVersion() {
     QBITTORRENT_VERSION=$(curl -s --connect-timeout 15 "https://api.github.com/repos/qbittorrent/qBittorrent/git/matching-refs/tags" | jq -Sr ".[].ref" | grep -v "alpha\|beta\|rc" | grep "^refs/tags/release-" | tail -n 1 | sed "s/refs\/tags\/release\-//")
     QSTASH_VERSION=$(curl -s --connect-timeout 15 "https://api.github.com/repos/upstash/qstash-cli/git/matching-refs/tags" | jq -Sr ".[].ref" | grep -v "rc" | grep "^refs/tags" | tail -n 1 | sed "s/refs\/tags\///")
     RCLONE_VERSION=$(curl -s --connect-timeout 15 "https://api.github.com/repos/rclone/rclone/git/matching-refs/tags" | jq -Sr ".[].ref" | grep "^refs/tags/v" | grep -v "\-" | tail -n 1 | sed "s/refs\/tags\/v//")
+    RCLONE_WEB_VERSION=$(curl -s --connect-timeout 15 "https://api.github.com/repos/rclone/rclone-web/git/matching-refs/tags" | jq -Sr ".[].ref" | grep "^refs/tags/" | grep -v "\-" | tail -n 1 | sed "s/refs\/tags\///")
     RUSTFS_VERSION=$(curl -s --connect-timeout 15 "https://api.github.com/repos/rustfs/rustfs/git/matching-refs/tags" | jq -Sr ".[].ref" | grep "^refs/tags/" | grep -v "alpha" | tail -n 1 | sed "s/refs\/tags\///")
     RUSTFS_WEB_VERSION=$(curl -s --connect-timeout 15 "https://api.github.com/repos/rustfs/console/git/matching-refs/tags" | jq -Sr ".[].ref" | grep "^refs/tags/v" | tail -n 1 | sed "s/refs\/tags\/v//")
     SEARXNG_VERSION=$(curl -s --connect-timeout 15 "https://api.github.com/repos/searxng/searxng/git/matching-refs/tags" | jq -Sr ".[].ref" | grep "^refs/tags/v" | tail -n 1 | sed "s/refs\/tags\/v//")

--- a/patch/template.json
+++ b/patch/template.json
@@ -69,6 +69,13 @@
       "source_branch": "master",
       "version": "{RCLONE_VERSION}"
     },
+    "rclone_web": {
+      "patch": "https://github.com/hezhijie0327/DockerimageBuilder.git",
+      "patch_branch": "main",
+      "source": "https://github.com/rclone/rclone-web.git",
+      "source_branch": "main",
+      "version": "{RCLONE_WEB_VERSION}"
+    },
     "rustfs": {
       "patch": "https://github.com/hezhijie0327/DockerimageBuilder.git",
       "patch_branch": "main",

--- a/repo/rclone.dockerfile
+++ b/repo/rclone.dockerfile
@@ -28,8 +28,12 @@ RUN \
     && export RCLONE_VERSION=$(cat "${WORKDIR}/rclone.version.autobuild") \
     && export PATCH_SHA=$(cd "${WORKDIR}/BUILDTMP/DOCKERIMAGEBUILDER" && git rev-parse --short HEAD | cut -c 1-4 | tr "a-z" "A-Z") \
     && export RCLONE_CUSTOM_VERSION="v${RCLONE_VERSION}-ZHIJIE-${RCLONE_SHA}${PATCH_SHA}" \
-    && echo "${RCLONE_CUSTOM_VERSION}" > "${WORKDIR}/BUILDTMP/RCLONE_WEB/RCLONE_CUSTOM_VERSION" \
-    && echo "${RCLONE_CUSTOM_VERSION}" > "${WORKDIR}/BUILDTMP/RCLONE/RCLONE_CUSTOM_VERSION"
+    && echo "${RCLONE_CUSTOM_VERSION}" > "${WORKDIR}/BUILDTMP/RCLONE/RCLONE_CUSTOM_VERSION" \
+    && export RCLONE_WEB_SHA=$(cd "${WORKDIR}/BUILDTMP/RCLONE_WEB" && git rev-parse --short HEAD | cut -c 1-4 | tr "a-z" "A-Z") \
+    && export RCLONE_WEB_VERSION=$(cat "${WORKDIR}/rclone_web.version.autobuild") \
+    && export RCLONE_WEB_CUSTOM_VERSION="v${RCLONE_WEB_VERSION}-ZHIJIE-${RCLONE_WEB_SHA}${PATCH_SHA}" \
+    && echo "${RCLONE_WEB_CUSTOM_VERSION}" > "${WORKDIR}/BUILDTMP/RCLONE_WEB/RCLONE_CUSTOM_VERSION" \
+    && sed -i "s/\"version\": \".*\"/\"version\": \"${RCLONE_WEB_CUSTOM_VERSION}\"/g" "${WORKDIR}/BUILDTMP/RCLONE_WEB/package.json"
 
 FROM node:${NODEJS_VERSION}-slim AS build_rclone_web
 

--- a/repo/rclone.dockerfile
+++ b/repo/rclone.dockerfile
@@ -1,4 +1,5 @@
 ARG GOLANG_VERSION="1"
+ARG NODEJS_VERSION="24"
 
 FROM ghcr.io/hezhijie0327/base:alpine AS get_info
 
@@ -13,19 +14,40 @@ RUN \
     && cat "${WORKDIR}/rclone.json" | jq -Sr ".patch" > "${WORKDIR}/rclone.patch.autobuild" \
     && cat "${WORKDIR}/rclone.json" | jq -Sr ".patch_branch" > "${WORKDIR}/rclone.patch_branch.autobuild" \
     && cat "${WORKDIR}/rclone.json" | jq -Sr ".version" > "${WORKDIR}/rclone.version.autobuild" \
+    && cat "/opt/package.json" | jq -Sr ".repo.rclone_web" > "${WORKDIR}/rclone_web.json" \
+    && cat "${WORKDIR}/rclone_web.json" | jq -Sr ".version" \
+    && cat "${WORKDIR}/rclone_web.json" | jq -Sr ".source" > "${WORKDIR}/rclone_web.source.autobuild" \
+    && cat "${WORKDIR}/rclone_web.json" | jq -Sr ".source_branch" > "${WORKDIR}/rclone_web.source_branch.autobuild" \
+    && cat "${WORKDIR}/rclone_web.json" | jq -Sr ".patch" > "${WORKDIR}/rclone_web.patch.autobuild" \
+    && cat "${WORKDIR}/rclone_web.json" | jq -Sr ".patch_branch" > "${WORKDIR}/rclone_web.patch_branch.autobuild" \
+    && cat "${WORKDIR}/rclone_web.json" | jq -Sr ".version" > "${WORKDIR}/rclone_web.version.autobuild" \
     && git clone -b $(cat "${WORKDIR}/rclone.source_branch.autobuild") --depth=1 $(cat "${WORKDIR}/rclone.source.autobuild") "${WORKDIR}/BUILDTMP/RCLONE" \
     && git clone -b $(cat "${WORKDIR}/rclone.patch_branch.autobuild") --depth=1 $(cat "${WORKDIR}/rclone.patch.autobuild") "${WORKDIR}/BUILDTMP/DOCKERIMAGEBUILDER" \
+    && git clone -b $(cat "${WORKDIR}/rclone_web.source_branch.autobuild") --depth=1 $(cat "${WORKDIR}/rclone_web.source.autobuild") "${WORKDIR}/BUILDTMP/RCLONE_WEB" \
     && export RCLONE_SHA=$(cd "${WORKDIR}/BUILDTMP/RCLONE" && git rev-parse --short HEAD | cut -c 1-4 | tr "a-z" "A-Z") \
     && export RCLONE_VERSION=$(cat "${WORKDIR}/rclone.version.autobuild") \
     && export PATCH_SHA=$(cd "${WORKDIR}/BUILDTMP/DOCKERIMAGEBUILDER" && git rev-parse --short HEAD | cut -c 1-4 | tr "a-z" "A-Z") \
     && export RCLONE_CUSTOM_VERSION="v${RCLONE_VERSION}-ZHIJIE-${RCLONE_SHA}${PATCH_SHA}" \
+    && echo "${RCLONE_CUSTOM_VERSION}" > "${WORKDIR}/BUILDTMP/RCLONE_WEB/RCLONE_CUSTOM_VERSION" \
     && echo "${RCLONE_CUSTOM_VERSION}" > "${WORKDIR}/BUILDTMP/RCLONE/RCLONE_CUSTOM_VERSION"
+
+FROM node:${NODEJS_VERSION}-slim AS build_rclone_web
+
+WORKDIR /rclone
+
+COPY --from=get_info /tmp/BUILDTMP/RCLONE_WEB /rclone
+
+RUN \
+    npm ci \
+    && npm run build
 
 FROM golang:${GOLANG_VERSION} AS build_rclone
 
 WORKDIR /rclone
 
 COPY --from=get_info /tmp/BUILDTMP/RCLONE /rclone
+
+COPY --from=build_rclone_web /rclone/dist /rclone/cmd/gui/dist
 
 ENV \
     CGO_ENABLED="0"


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

将 rclone-web 的构建和版本管理加入到 rclone 镜像构建流水线中。

新功能：
- 使用上游的 rclone-web 仓库，将 rclone-web 前端打包进 rclone Docker 镜像。

增强：
- 通过新增的 Docker 构建参数，对用于构建 rclone-web 资源的 Node.js 版本进行参数化配置。

构建：
- 扩展 rclone 的 Dockerfile，以获取、构建并将 rclone-web 资源嵌入到 rclone GUI 目录中。

杂项：
- 在 package.json 和发布脚本中跟踪 rclone-web 的元数据和最新发行版本，与现有组件保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add rclone-web build and versioning into the rclone image build pipeline.

New Features:
- Bundle the rclone-web frontend into the rclone Docker image using the upstream rclone-web repository.

Enhancements:
- Parameterize the Node.js version used to build rclone-web assets via a new Docker build argument.

Build:
- Extend the rclone Dockerfile to fetch, build, and embed rclone-web assets into the rclone GUI directory.

Chores:
- Track rclone-web metadata and latest release version in package.json and the release script alongside existing components.

</details>